### PR TITLE
Makes exceptions for appearance vendor prefixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [1.0.1] - 2021-02-24
+
+- Allows prefixed properties for `appearance`. `-moz-appearance` and `-webkit-appearance` are commonly used for button and select styling since they can't be auto-prefixed easily.
+
 ## [1.0.0] - 2021-01-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-apostrophe",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "stylelint configuration for apostrophe and related core modules",
   "main": "index.js",
   "scripts": {

--- a/stylelintrc.json
+++ b/stylelintrc.json
@@ -113,7 +113,9 @@
     "number-no-trailing-zeros": true,
     "property-case": "lower",
     "property-no-unknown": true,
-    "property-no-vendor-prefix": true,
+    "property-no-vendor-prefix": [true, {
+      "ignoreProperties": ["appearance"]
+    }],
     "rule-empty-line-before": [
       "always-multi-line",
       {


### PR DESCRIPTION
These are our most common cases (afaik) of overriding stylelint config. It seems reasonable to simply ignore them.

CC @stuartromanek 