### PR TITLE
stringify rules to prevent false positives from deeply nested rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [1.0.1] - 2021-03-24
+
+## Fixed
+
+- Update to prevent false positives when running `compare`
+
 ## [1.0.0] - 2021-01-27
 
 ### Added
 
 - Initial release of an ApostropheCMS team stylelint configuration. This is based on `stylelint-config-punkave` rules, with additional scripts for keeping up to date with the standard stylelint config.
+
+[1.0.1]: https://github.com/apostrophecms/stylelint-config-apostrophe/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/apostrophecms/stylelint-config-apostrophe/releases/tag/1.0.0

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,8 @@ const diff = (theirs, ours) => {
 
   const rules = Object.keys(ours);
   rules.forEach(rule => {
-    if (ours[rule] === theirs[rule]) {
+
+    if (JSON.stringify(ours[rule]) === JSON.stringify(theirs[rule])) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-apostrophe",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "stylelint configuration for apostrophe and related core modules",
   "main": "index.js",
   "scripts": {

--- a/test/utils.js
+++ b/test/utils.js
@@ -64,4 +64,22 @@ describe("eslint-config-apostrophe:utils", function() {
     const actual = utils.diff(a, b);
     assert.deepEqual(expected, actual);
   });
+
+  it("should find differerences in deeply nested complex rules and ignore spacing", function() {
+    const a = {
+      "declaration-empty-line-before": ["always",{"except":["after-declaration","first-nested"],"ignore":["after-comment","inside-single-line-block"]}]
+    };
+    const b = {
+      "declaration-empty-line-before": [ "always", { "except": [ "after-declaration" ], "ignore": [ "after-comment", "inside-single-line-block" ] } ]
+    };
+
+    const expected = new Map();
+    expected.set("declaration-empty-line-before", {
+      standard: ["always",{"except":["after-declaration","first-nested"],"ignore":["after-comment","inside-single-line-block"]}],
+      modified: ["always",{"except":["after-declaration"],"ignore":["after-comment","inside-single-line-block"]}]
+    });
+
+    const actual = utils.diff(a, b);
+    assert.deepEqual(expected, actual);
+  });
 });


### PR DESCRIPTION
Fixes the issue we saw in the demo on Tuesday. 