### PR TITLE
ignores inside functions for declaration-property-unit-allowed-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- Ignores inside CSS and preprocessor functions for the `declaration-property-unit-allowed-list` rule. Those functions do not represent the ultimate property unit after compiling.
+
 ## [1.0.1] - 2021-03-24
 
-## Fixed
+### Fixed
 
 - Update to prevent false positives when running `compare`
 

--- a/stylelintrc.json
+++ b/stylelintrc.json
@@ -70,13 +70,17 @@
       }
     ],
     "declaration-no-important": true,
-    "declaration-property-unit-allowed-list": {
-      "/^animation/": ["ms"],
-      "/^border/": ["px"],
-      "font-size": ["rem"],
-      "line-height": [],
-      "/^transition/": ["ms"]
-    },
+    "declaration-property-unit-allowed-list": [
+      {
+        "/^animation/": ["ms"],
+        "/^border/": ["px"],
+        "font-size": ["rem"],
+        "line-height": [],
+        "/^transition/": ["ms"]
+      }, {
+        "ignore": ["inside-function"]
+      }
+    ],
     "function-calc-no-invalid": true,
     "function-calc-no-unspaced-operator": true,
     "function-comma-newline-after": "always-multi-line",


### PR DESCRIPTION
This avoids false positives when we do things like use percentages in CSS/SCSS functions that will ultimately compile to something else or are part of the spec (e.g., `hsla()`).

So `color: border-color: lighten(#000, 40%)` would currently throw an error since we require px for border, but would not anymore with this change.

A new rule option PR'd by yours truly. https://github.com/stylelint/stylelint/pull/5194 (may not be released yet).