### PR TITLE
update order rules

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -145,7 +145,19 @@
         "ignoreValues": ["box", "inline-box"]
       }
     ],
-    "order/order": ["declarations", "rules", "at-rules"],
+    "order/order": [
+      {
+        "type": "at-rule",
+        "hasBlock": false
+      },
+      "dollar-variables",
+      "declarations",
+      "rules",
+      {
+        "type": "at-rule",
+        "name": "media"
+      }
+    ],
     "order/properties-order": [
       "z-index",
       "position",


### PR DESCRIPTION
## Summary

Add flexibility for `@extend` and `@include` and force `@media` last.

## What are the specific steps to test this change?

1. Given:

```
.apos-doc-version__view-options-menu__item {
  &__button {
    @include apos-button-reset();

    display: flex;
    gap: 20px;
    align-items: center;
    justify-content: space-between;
    cursor: pointer;
    width: 100%;
    padding: 10px 20px;
  }
}
```

`stylelint` should pass

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
