### PR TITLE
adds support for vue files

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["stylelint-config-html/vue"],
   "plugins": [
     "stylelint-declaration-strict-value",
     "stylelint-order",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Fixed
+
+- Add support for vue files by using `stylelint-config-html/vue`.
+
 ## 3.0.2 (2024-03-08)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "stylelint": ">= 15.6.0"
   },
   "dependencies": {
+    "stylelint-config-html": "^1.1.0",
     "stylelint-config-standard": "^33.0.0",
     "stylelint-declaration-strict-value": "^1.9.2",
     "stylelint-order": "^6.0.3",
@@ -30,10 +31,10 @@
   },
   "devDependencies": {
     "eslint": "^8.39.0",
+    "eslint-config-apostrophe": "^4.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-promise": "^6.1.1",
-    "eslint-config-apostrophe": "^4.0.0",
     "mocha": "^10.2.0",
     "postcss-scss": "^4.0.6"
   }


### PR DESCRIPTION
## Summary

Stylelint was broken on vue files:
![image](https://github.com/apostrophecms/stylelint-config-apostrophe/assets/17548370/d28351fe-e47c-45fb-9258-4ef2842ac285)

This new plugin supports vue files.

You can test int [this project](https://github.com/apostrophecms/multisite-dashboard) to run the commande `npm run stylelint` without and with this changes.
