### PR TITLE
add postcss-scss to handle comments properly

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -243,5 +243,11 @@
     ],
     "scss/dollar-variable-pattern": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
     "scss/no-duplicate-mixins": true
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.scss", "**/*.scss"],
+      "customSyntax": "postcss-scss"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Added
+
+- Include `postcss-scss` to parse Scss files correctly
+
 ## 4.0.0 (2024-05-15)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compare": "node ./lib/index",
     "eslint": "npx eslint .",
-    "stylelint": "npx stylelint 'test/*.scss' --custom-syntax postcss-scss --config .stylelintrc.json",
+    "stylelint": "npx stylelint 'test/*.scss' --config .stylelintrc.json",
     "test": "npx mocha"
   },
   "repository": {


### PR DESCRIPTION
## Summary

Fixes an error where our current config was throwing a syntax error for `//` style comments. 

## What are the specific steps to test this change?

1. Add a `//` style comment in a Scss file.
1. run the linter `npm run stylelint` or `npx stylelint "**/*.{scss,vue}"` if you don't have a stylelint task in your project
1. Linter should not have a `CssSyntaxError`

## What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [X] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
