### PR TITLE
add custom "require-nested-after-include" rule to enforce sass mixed-decls rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,8 @@
   "plugins": [
     "stylelint-declaration-strict-value",
     "stylelint-order",
-    "stylelint-scss"
+    "stylelint-scss",
+    "./plugins/require-nested-after-include.js"
   ],
   "ignoreFiles": ["node_modules/**/*", "**/node_modules/**/*"],
   "rules": {
@@ -244,7 +245,8 @@
     ],
     "scss/dollar-variable-pattern": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
     "scss/load-partial-extension": "never",
-    "scss/no-duplicate-mixins": true
+    "scss/no-duplicate-mixins": true,
+    "custom/require-nested-after-include": true
   },
   "overrides": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 * Replace deprecated `at-import-partial-extension` with `load-partial-extension`.
+* Add "custom/require-nested-after-include" rule to enforce the new Sass "Mixed Declarations" rule (see https://sass-lang.com/documentation/breaking-changes/mixed-decls/).
 
 ## 4.1.0 (2024-06-12)
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "eslint": "npx eslint .",
     "lint": "npm run eslint && npm run stylelint",
     "pretest": "npm run lint",
-    "stylelint": "npx stylelint 'test/*.scss' --config .stylelintrc.json",
-    "test": "npx mocha"
+    "stylelint": "npx stylelint 'test/lib/*.scss' --config .stylelintrc.json",
+    "test": "npx mocha './test/**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/plugins/require-nested-after-include.js
+++ b/plugins/require-nested-after-include.js
@@ -1,0 +1,36 @@
+const stylelint = require('stylelint');
+
+const ruleName = 'custom/require-nested-after-include';
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  expected: 'Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls'
+});
+
+module.exports = stylelint.createPlugin(ruleName, () => {
+  return (root, result) => {
+    root.walkRules((rule) => {
+      rule.walkAtRules('include', (atRule) => {
+        const nextNode = atRule.next();
+
+        if (
+          !nextNode ||
+          (nextNode.type === 'rule' && nextNode.selector.startsWith('& {')) ||
+          (nextNode.type === 'atrule')
+        ) {
+          return;
+        }
+
+        if (nextNode.type === 'decl') {
+          stylelint.utils.report({
+            message: messages.expected,
+            node: atRule,
+            result,
+            ruleName
+          });
+        }
+      });
+    });
+  };
+});
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/plugins/require-nested-after-include.js
+++ b/plugins/require-nested-after-include.js
@@ -11,15 +11,7 @@ module.exports = stylelint.createPlugin(ruleName, () => {
       rule.walkAtRules('include', (atRule) => {
         const nextNode = atRule.next();
 
-        if (
-          !nextNode ||
-          (nextNode.type === 'rule' && nextNode.selector.startsWith('& {')) ||
-          (nextNode.type === 'atrule')
-        ) {
-          return;
-        }
-
-        if (nextNode.type === 'decl') {
+        if (nextNode?.type === 'decl') {
           stylelint.utils.report({
             message: messages.expected,
             node: atRule,

--- a/test/lib/index.scss
+++ b/test/lib/index.scss
@@ -48,7 +48,7 @@ html {
   font-size: 1rem;
 }
 
-@media (320px < min-width) {
+@media (min-width < 320px) {
   .one {
     color: $grey;
   }

--- a/test/lib/index.scss
+++ b/test/lib/index.scss
@@ -48,7 +48,7 @@ html {
   font-size: 1rem;
 }
 
-@media (min-width < 320px) {
+@media (320px < min-width) {
   .one {
     color: $grey;
   }

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const utils = require('../lib/utils');
+const utils = require('../../lib/utils');
 
 describe('eslint-config-apostrophe:utils', function() {
   it('should find missing rules', function() {

--- a/test/plugins/require-nested-after-include/bad.scss
+++ b/test/plugins/require-nested-after-include/bad.scss
@@ -1,0 +1,5 @@
+.foo {
+  @include something();
+
+  text-decoration: underline;
+}

--- a/test/plugins/require-nested-after-include/good-1.scss
+++ b/test/plugins/require-nested-after-include/good-1.scss
@@ -1,0 +1,7 @@
+.foo {
+  @include something();
+
+  & {
+    text-decoration: underline;
+  }
+}

--- a/test/plugins/require-nested-after-include/good-2.scss
+++ b/test/plugins/require-nested-after-include/good-2.scss
@@ -1,0 +1,3 @@
+.foo {
+  @include something();
+}

--- a/test/plugins/require-nested-after-include/require-nested-after-include.js
+++ b/test/plugins/require-nested-after-include/require-nested-after-include.js
@@ -1,0 +1,33 @@
+/* eslint-disable n/handle-callback-err */
+
+// NOTE: tried https://stylelint.io/developer-guide/plugins/#testing but it would not work with our CommonJS usage.
+
+const assert = require('assert');
+const { exec } = require('node:child_process');
+
+const ERROR_MESSAGE = 'Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls';
+
+describe('require-nested-after-include stylelint rule', function() {
+  this.timeout(10000);
+
+  it('should fail when a declaration after an at-rule is not scoped into a `& { ... }` block', function(done) {
+    exec('npx stylelint test/plugins/require-nested-after-include/bad.scss', (error, stdout, stderr) => {
+      assert(stderr.includes(ERROR_MESSAGE));
+      done();
+    });
+  });
+
+  it('should pass when a declaration after an at-rule is scoped into a `& { ... }` block', function(done) {
+    exec('npx stylelint test/plugins/require-nested-after-include/good-1.scss', (error, stdout, stderr) => {
+      assert(!stderr.includes(ERROR_MESSAGE));
+      done();
+    });
+  });
+
+  it('should pass when there is no declaration after an at-rule', function(done) {
+    exec('npx stylelint test/plugins/require-nested-after-include/good-2.scss', (error, stdout, stderr) => {
+      assert(!stderr.includes(ERROR_MESSAGE));
+      done();
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

```
➜  apostrophe git:(main) run stylelint

modules/@apostrophecms/schema/ui/apos/scss/AposInputArray.scss
  189:3  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include
  271:3  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include
  303:5  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include
  303:5  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include

modules/@apostrophecms/ui/ui/apos/scss/global/_tables.scss
  20:3  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include

modules/@apostrophecms/image/ui/apos/components/AposMediaUploader.vue
  340:5  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include

modules/@apostrophecms/ui/ui/apos/components/AposContextMenu.vue
  334:3  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include

modules/@apostrophecms/ui/ui/apos/components/AposContextMenuDialog.vue
  139:3  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include

modules/@apostrophecms/ui/ui/apos/components/AposLocalePicker.vue
  152:3  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include

modules/@apostrophecms/ui/ui/apos/components/AposSlatList.vue
  200:5  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include

modules/@apostrophecms/ui/ui/apos/components/AposTagApply.vue
  318:5  ✖  Expected "& { ... }" block after "@include" at-rule if declarations are present. See https://sass-lang.com/documentation/breaking-changes/mixed-decls  custom/require-nested-after-include

✖ 11 problems (11 errors, 0 warnings)
```

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
